### PR TITLE
Support goog.declareModuleId

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-const provideRegex = /^\s*goog\.(?:provide|module)(?:\.declareNamespace)?\(\s*['"]([^'"]+)['"]\s*\)/gm;
+const provideRegex = /^\s*goog\.(?:provide|module|declareModuleId)(?:\.declareNamespace)?\(\s*['"]([^'"]+)['"]\s*\)/gm;
 const requireRegex = /^\s*(?:(?:var|let|const)\s*[^=]*\s*=\s*)?goog\.require\(['"]([^'"]*)['"]\)/gm;
 const es6ImportRegex = /^\s*import\s{?\s*?[a-zA-Z_$][\w$,\s]*}?\sfrom\s(?:'|")([\w-_./]+)(?:'|")/gm;
 const closureScriptRegex = /^\s*goog\.provide\(\s*['"](?:.+?)['"]\s*\)/m;


### PR DESCRIPTION
goog.declareModuleId is a new API coming with a recent release of Closure library, this is a replacement for goog.module.declareNamespace.